### PR TITLE
specify phantomjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-markdown": "^0.7.0",
     "grunt-mocha-phantomjs": "^2.0.1",
+    "phantomjs": "^1.9.8",
     "mocha-phantomjs": "^4.0.2"
   },
   "dependencies": {


### PR DESCRIPTION
according to https://github.com/mozilla/id.webmaker.org/pull/383, mocha-phantomjs uses non-exist phantomjs version, which causes the build failing  