### PR TITLE
Update Contributing.md #58

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -4,7 +4,7 @@
 Thanks for contributing! Developing Umbrella is quite easy:
 
 1. Clone the repository  
-`git clone git://github.com/umbrellajs/umbrella.git/ && cd ./umbrella`
+`git clone git://github.com/umbrellajs/umbrella.git && cd ./umbrella`
 1. Install the dependencies   
 `npm install`
 1. Install grunt if you didn't have it  

--- a/Contributing.md
+++ b/Contributing.md
@@ -1,11 +1,10 @@
 # Contributing
 
-> Please use the branch "2" for changes/new features until this notice is removed
 
 Thanks for contributing! Developing Umbrella is quite easy:
 
 1. Clone the repository  
-`git clone git://github.com/umbrellajs/umbrella.git/ umbrellajs && cd ./umbrellajs`
+`git clone git://github.com/umbrellajs/umbrella.git/ && cd ./umbrella`
 1. Install the dependencies   
 `npm install`
 1. Install grunt if you didn't have it  

--- a/Contributing.md
+++ b/Contributing.md
@@ -4,9 +4,12 @@
 
 Thanks for contributing! Developing Umbrella is quite easy:
 
-1. Clone the repository `git clone git+https://github.com/umbrellajs/umbrella.git && cd ./umbrellajs`
-1. Install the dependencies `npm install`
-1. Install grunt if you didn't have it
+1. Clone the repository  
+`git clone git://github.com/umbrellajs/umbrella.git/ umbrellajs && cd ./umbrellajs`
+1. Install the dependencies   
+`npm install`
+1. Install grunt if you didn't have it  
+`npm install -g grunt-cli`
 1. Run `grunt watch`
 1. Modify any file within `/src` (code, tests or documentation)
 


### PR DESCRIPTION
## Issue #58: (modified from PR #59)
1. git clone incorrect address
2. cd to a non existent directory
3. missing instructions on how to install grunt
4. remove branch 2 notification

**Changes**   
1. Changed GIT clone url
2. Updated clone directory name
3. added grunt installation step

**To Verify**  
- Verify by viewing file: https://github.com/oscarmorrison/umbrella/blob/002061b057aeebd0e11e43ea8b1d9874705f6a1b/Contributing.md
 
**Notes:**
https://git-scm.com/docs/git-clone#URLS
References the correct GIT url schemes. 
git+https is a npm helper that needs to be installed. Returns the error:
> Unable to find remote helper for 'git+https'
